### PR TITLE
37 CFR 1: markers in GPOTABLEs

### DIFF
--- a/annual/CFR-2012-title37-vol1-part1.xml
+++ b/annual/CFR-2012-title37-vol1-part1.xml
@@ -4508,9 +4508,10 @@
           <SUBJECT>International application filing, processing and search fees.</SUBJECT>
           <P>(a) The following fees and charges for international applications are established by law or by the Director under the authority of 35 U.S.C. 376:</P>
           <P>(1) A transmittal fee (see 35 U.S.C. 361(d) and PCT Rule 14) consisting of:</P>
+          <P>(i)</P>
           <GPOTABLE CDEF="s30,8" COLS="2" OPTS="L0,tp0,p1,8/9,g1,t1">
             <ROW>
-              <ENT I="01">(i) A basic portion</ENT>
+              <ENT I="01">A basic portion</ENT>
               <ENT>$240.00</ENT>
             </ROW>
           </GPOTABLE>

--- a/annual/CFR-2013-title37-vol1-part1.xml
+++ b/annual/CFR-2013-title37-vol1-part1.xml
@@ -1934,8 +1934,10 @@
           </GPOTABLE>
           <P>§ 1.217—for processing a redacted copy of a paper submitted in the file of an application in which a redacted copy was submitted for the patent application publication.</P>
           <P>§ 1.221—for requesting voluntary publication or republication of an application.</P>
-          <P>(j) [Reserved]</P>
           <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,8/9,g1,t1">
+            <ROW>
+              <ENT>(j) [Reserved]</ENT>
+            </ROW>
             <ROW>
               <ENT I="22">(k) For filing a request for expedited examination under § 1.155(a):</ENT>
             </ROW>


### PR DESCRIPTION
[`eregs/regulations-parser`](https://github.com/eregs/regulations-parser) does not currently process regulatory markers found within `GPOTABLE` objects (see [issue 368](https://github.com/eregs/regulations-parser/issues/368)).  This causes the parser to fail in circumstances where the depth of regulatory markers around a `GPOTABLE` object cannot be accurately determined.

This pull request fixes two of these errors found in the 37 CFR 1 2012 and 2013 annual editions.