### PR TITLE
37 CFR 1: empty SECTION at end of Subpart E

### DIFF
--- a/annual/CFR-2013-title37-vol1-part1.xml
+++ b/annual/CFR-2013-title37-vol1-part1.xml
@@ -6039,10 +6039,6 @@
         <P>(3) Issues in addition to those raised by patents and printed publications, and by subject matter added or deleted during a reexamination proceeding, may be considered and resolved, notwithstanding § 1.552(c); and</P>
         <P>(4) Information material to patentability will be defined by § 1.56(b), notwithstanding § 1.555(b).</P>
       </SECTION>
-      <SECTION>
-        <SECTNO/>
-        <SUBJECT/>
-      </SECTION>
     </SUBPART>
     <SUBPART>
       <HD SOURCE="HED">Subpart F—Adjustment and Extension of Patent Term</HD>

--- a/annual/CFR-2014-title37-vol1-part1.xml
+++ b/annual/CFR-2014-title37-vol1-part1.xml
@@ -5849,10 +5849,6 @@
         <P>(3) Issues in addition to those raised by patents and printed publications, and by subject matter added or deleted during a reexamination proceeding, may be considered and resolved, notwithstanding § 1.552(c); and</P>
         <P>(4) Information material to patentability will be defined by § 1.56(b), notwithstanding § 1.555(b).</P>
       </SECTION>
-      <SECTION>
-        <SECTNO/>
-        <SUBJECT/>
-      </SECTION>
     </SUBPART>
     <SUBPART>
       <HD SOURCE="HED">Subpart F—Adjustment and Extension of Patent Term</HD>


### PR DESCRIPTION
The 2013 and 2014 annual editions of 37 CFR 1 include an empty `SECTION` at the end of Subpart E "Supplemental Examination of Patents".  Code in `eregs/regulation-parser` doesn't anticipate this usage, specifically at [`regparser/tree/gpo_cfr/section.py#L120`](https://github.com/eregs/regulations-parser/blob/master/regparser/tree/gpo_cfr/section.py#L120).  This PR removes the empty `SECTION` objects.