### PR TITLE
Adding FR 04-16753

### DIFF
--- a/documents/full_text/xml/2004/07/22/04-16753.xml
+++ b/documents/full_text/xml/2004/07/22/04-16753.xml
@@ -1,0 +1,134 @@
+<RULE>
+      <PREAMB>
+        <AGENCY TYPE="N">DEPARTMENT OF COMMERCE </AGENCY>
+        <SUBAGY>Patent and Trademark Office </SUBAGY>
+        <CFR>37 CFR Parts 1 and 2 </CFR>
+        <DEPDOC>[Docket No. 2004-C-032] </DEPDOC>
+        <RIN>RIN 0651-AB74 </RIN>
+        <SUBJECT>Elimination of Credit Cards as Payment for Replenishing Deposit Accounts </SUBJECT>
+        <AGY>
+          <HD SOURCE="HED">AGENCY:</HD>
+          <P>United States Patent and Trademark Office, Commerce. </P>
+        </AGY>
+        <ACT>
+          <HD SOURCE="HED">ACTION:</HD>
+          <P>Final rule. </P>
+        </ACT>
+        <SUM>
+          <HD SOURCE="HED">SUMMARY:</HD>
+
+          <P>The United States Patent and Trademark Office (Office) is amending its rules of practice to eliminate acceptance of credit cards as payment for replenishing deposit accounts. Deposit account customers may still submit payments to replenish their deposit accounts by electronic funds transfer (EFT) through the Federal Reserve Fedwire System or over the Office's Internet Web site (<E T="03">http://www.uspto.gov</E>), and by check or money order sent through the mail. The Office will continue to accept credit cards as payment for all other products and services for which fees are required.</P>
+        </SUM>
+        <EFFDATE>
+          <HD SOURCE="HED">DATES:</HD>
+          <P>
+            <E T="03">Effective Date:</E> August 23, 2004. </P>
+        </EFFDATE>
+        <FURINF>
+          <HD SOURCE="HED">FOR FURTHER INFORMATION CONTACT:</HD>
+          <P>Matthew Lee by e-mail at <E T="03">matthew.lee@uspto.gov,</E> or by fax at (703) 308-5077 marked to the attention of Matthew Lee. </P>
+        </FURINF>
+      </PREAMB>
+      <SUPLINF>
+        <HD SOURCE="HED">SUPPLEMENTARY INFORMATION:</HD>
+        <P>The Office is revising 37 CFR 1.23(b), 1.25(c)(2), 2.207(b), and 2.208(c)(2) to eliminate acceptance of credit cards as payment for replenishing deposit accounts. </P>
+        <P>The Office participates in the Plastic Card Network (PCN), which is a Government-wide network that allows Federal agencies to accept nationally branded credit and debit cards for collecting receipts due to the Government. This network promotes the efficient electronic collection of receipts from the public sector while providing a convenient and widely used payment option for remitters. The Department of the Treasury Financial Management Service (FMS) manages the PCN and pays the transaction fees incurred for processing credit and debit card payments. </P>
+        <P>The Office was notified by the FMS of excessive transaction fees resulting from high dollar credit card charges processed by the agency. Nearly all of the high dollar credit card charges were payments made by customers to replenish deposit accounts. Although credit cards are an efficient means for individuals to use in replenishing deposit accounts, they are an expensive option that is not cost-effective. It is much more cost-effective to process high dollar payments by EFT or by check for the Government. This is because the Government is charged a percent fee based on the total dollar amount of the charge. Under the PCN, the Office is not allowed to establish minimum or maximum single transaction amounts or to charge a transaction fee for a specific group of transactions as conditions for accepting credit cards. </P>
+        <P>Deposit account customers who replenished their deposit accounts with a credit card may be inconvenienced, but the vast majority of customers who pay for products and services with a credit card will continue to enjoy the convenience and will not be impacted by this final rule. Customers will continue to have a means of replenishing their deposit accounts electronically by EFT, and through the mail by check or money order. </P>
+        <P>This final rule supports the FMS in controlling the PCN costs, and ensures the Office can continue participating in the PCN and provide the credit card payment option to customers for all other products and services. </P>
+        <P>To ensure clarity in the implementation of this final rule, a discussion of specific sections is set forth below. </P>
+        <HD SOURCE="HD1">Discussion of Specific Rules </HD>
+        <HD SOURCE="HD2">37 CFR 1.23 Method of Payment </HD>
+        <P>Section 1.23, paragraph (b), is revised to exclude credit cards as payment for replenishing a deposit account. </P>
+        <HD SOURCE="HD2">37 CFR 1.25 Deposit Accounts </HD>
+        <P>Section 1.25, paragraph (c)(2), is revised by removing the reference to credit cards for replenishing a deposit account over the Office's Internet Web site. </P>
+        <HD SOURCE="HD2">37 CFR 2.207 Method of Payment </HD>
+        <P>Section 2.207, paragraph (b), is revised to exclude credit cards as payment for replenishing a deposit account. </P>
+        <HD SOURCE="HD2">37 CFR 2.208 Deposit Accounts </HD>
+        <P>Section 2.208, paragraph (c)(2), is revised by removing the reference to credit cards for replenishing a deposit account over the Office's Internet Web site. </P>
+        <HD SOURCE="HD1">Other Considerations </HD>
+
+        <P>This final rule contains no information collection requirements within the meaning of the Paperwork Reduction Act of 1995, 44 U.S.C. 3501 <E T="03">et seq.</E> This final rule has been determined to be not significant for purposes of Executive Order 12866. This final rule does not contain policies with Federalism implications sufficient to warrant preparation of a Federalism Assessment under Executive Order 13132 (August 4, 1999). </P>
+        <P>Prior notice and an opportunity for public comment are not required by the Administrative Procedure Act, or any other statute or regulation, for this rule. This rule is exempted from the notice and comment because it involves a rule of agency practice or procedure. As prior notice and an opportunity for public comment are not required pursuant to 5 U.S.C. 553, or any other law, the analytical requirements of the Regulatory Flexibility Act, 5 U.S.C. 605(b), are inapplicable. </P>
+        <LSTSUB>
+          <HD SOURCE="HED">Lists of Subjects </HD>
+          <CFR>37 CFR Part 1 </CFR>
+          <P>Administrative practice and procedure, Patents. </P>
+          <CFR>37 CFR Part 2 </CFR>
+          <P>Administrative practice and procedure, Trademarks.</P>
+        </LSTSUB>
+        <REGTEXT PART="1" TITLE="37">
+
+          <AMDPAR>For the reasons set forth in the preamble, title 37 of the Code of Federal Regulations, parts 1 and 2, are being amended as set forth below. <PRTPAGE P="43752"/>
+          </AMDPAR>
+          <PART>
+            <HD SOURCE="HED">PART 1—RULES OF PRACTICE IN PATENT CASES </HD>
+          </PART>
+          <AMDPAR>1. The authority citation for 37 CFR part 1 continues to read as follows: </AMDPAR>
+          <AUTH>
+            <HD SOURCE="HED">Authority:</HD>
+            <P>35 U.S.C. 2, unless otherwise noted. </P>
+          </AUTH>
+        </REGTEXT>
+        
+        <REGTEXT PART="1" TITLE="37">
+          <AMDPAR>2. Section 1.23 is amended by revising paragraph (b) to read as follows: </AMDPAR>
+          <SECTION>
+            <SECTNO>§ 1.23 </SECTNO>
+            <SUBJECT>Methods of payment. </SUBJECT>
+            <STARS/>
+            <P>(b) Payments of money required for United States Patent and Trademark Office fees may also be made by credit card, except for replenishing a deposit account. Payment of a fee by credit card must specify the amount to be charged to the credit card and such other information as is necessary to process the charge, and is subject to collection of the fee. The Office will not accept a general authorization to charge fees to a credit card. If credit card information is provided on a form or document other than a form provided by the Office for the payment of fees by credit card, the Office will not be liable if the credit card number becomes public knowledge. </P>
+          </SECTION>
+        </REGTEXT>
+        <REGTEXT PART="1" TITLE="37">
+          <AMDPAR>3. Section 1.25 is amended by revising paragraph (c)(2) to read as follows: </AMDPAR>
+          <SECTION>
+            <SECTNO>§ 1.25 </SECTNO>
+            <SUBJECT>Deposit accounts. </SUBJECT>
+            <STARS/>
+            <P>(c) *** </P>
+
+            <P>(2) A payment to replenish a deposit account may be submitted by electronic funds transfer over the Office's Internet Web site (<E T="03">www.uspto.gov</E>). </P>
+            <STARS/>
+          </SECTION>
+        </REGTEXT>
+        <REGTEXT PART="2" TITLE="37">
+          <PART>
+            <HD SOURCE="HED">PART 2—RULES OF PRACTICE IN TRADEMARK CASES </HD>
+          </PART>
+          <AMDPAR>1. The authority citation for 37 CFR part 2 continues to read as follows: </AMDPAR>
+          <AUTH>
+            <HD SOURCE="HED">Authority:</HD>
+            <P>35 U.S.C. 2, unless otherwise noted. </P>
+          </AUTH>
+        </REGTEXT>
+        <REGTEXT PART="2" TITLE="37">
+          <AMDPAR>2. Section 2.207 is amended by revising paragraph (b) to read as follows: </AMDPAR>
+          <SECTION>
+            <SECTNO>§ 2.207 </SECTNO>
+            <SUBJECT>Methods of payment. </SUBJECT>
+            <STARS/>
+            <P>(b) Payments of money required for trademark fees may also be made by credit card, except for replenishing a deposit account. Payment of a fee by credit card must specify the amount to be charged to the credit card and such other information as is necessary to process the charge, and is subject to collection of the fee. The Office will not accept a general authorization to charge fees to a credit card. If credit card information is provided on a form or document other than a form provided by the Office for the payment of fees by credit card, the Office will not be liable if the credit card number becomes public knowledge. </P>
+          </SECTION>
+        </REGTEXT>
+        <REGTEXT PART="2" TITLE="37">
+          <AMDPAR>3. Section 2.208 is amended by revising paragraph (c)(2) to read as follows: </AMDPAR>
+          <SECTION>
+            <SECTNO>§ 2.208 </SECTNO>
+            <SUBJECT>Deposit accounts. </SUBJECT>
+            <STARS/>
+            <P>(c) *** </P>
+
+            <P>(2) A payment to replenish a deposit account may be submitted by electronic funds transfer over the Office's Internet Web site (<E T="03">www.uspto.gov</E>). </P>
+            <STARS/>
+          </SECTION>
+        </REGTEXT>
+        <SIG>
+          <DATED>Dated: July 14, 2004. </DATED>
+          <NAME>Jon W. Dudas, </NAME>
+          <TITLE>Acting Under Secretary of Commerce for Intellectual Property and Acting Director of the United States Patent and Trademark Office. </TITLE>
+        </SIG>
+      </SUPLINF>
+      <FRDOC>[FR Doc. 04-16753 Filed 7-21-04; 8:45 am] </FRDOC>
+      <BILCOD>BILLING CODE 3510-16-P</BILCOD>
+    </RULE>

--- a/documents/full_text/xml/2004/07/22/04-16753.xml
+++ b/documents/full_text/xml/2004/07/22/04-16753.xml
@@ -70,7 +70,7 @@
             <P>35 U.S.C. 2, unless otherwise noted. </P>
           </AUTH>
         </REGTEXT>
-        
+
         <REGTEXT PART="1" TITLE="37">
           <AMDPAR>2. Section 1.23 is amended by revising paragraph (b) to read as follows: </AMDPAR>
           <SECTION>
@@ -87,7 +87,7 @@
             <SUBJECT>Deposit accounts. </SUBJECT>
             <STARS/>
             <P>(c) *** </P>
-
+            <P>(1) *** </P>
             <P>(2) A payment to replenish a deposit account may be submitted by electronic funds transfer over the Office's Internet Web site (<E T="03">www.uspto.gov</E>). </P>
             <STARS/>
           </SECTION>
@@ -118,7 +118,7 @@
             <SUBJECT>Deposit accounts. </SUBJECT>
             <STARS/>
             <P>(c) *** </P>
-
+            <P>(1) *** </P>
             <P>(2) A payment to replenish a deposit account may be submitted by electronic funds transfer over the Office's Internet Web site (<E T="03">www.uspto.gov</E>). </P>
             <STARS/>
           </SECTION>


### PR DESCRIPTION
There are two amendments in [FR 04-16753](https://www.federalregister.gov/d/04-16753) which omit interim markers, causing `regulations-parser` to be unable to derive paragraph depths.

Reproduction of the error can be accomplished using `regulations-parser`:

```bash
eregs clear
eregs preprocess_notice 04-16753
eregs write_to output
```

The following changes were introduced to [the source FR XML document](https://www.federalregister.gov/documents/full_text/xml/2004/07/22/04-16753.xml):

1. For [37 CFR 1 amendment 3](https://www.federalregister.gov/d/04-16753/p-amd-4), an asterisk node has been added for § 1.25 (c)(1).
1. For [37 CFR 2 amendment 3](https://www.federalregister.gov/d/04-16753/p-amd-7), an asterisk node has been added for § 2.208 (c)(1).

These changes enable the parser to correctly identify the paragraph depths and process the amendments.