### PR TITLE
Adding FR 2011-29462

### DIFF
--- a/documents/full_text/xml/2011/11/15/2011-29462.xml
+++ b/documents/full_text/xml/2011/11/15/2011-29462.xml
@@ -1,0 +1,167 @@
+<RULE>
+      <PREAMB>
+        <AGENCY TYPE="N">DEPARTMENT OF COMMERCE</AGENCY>
+        <SUBAGY>Patent and Trademark Office</SUBAGY>
+        <CFR>37 CFR Part 1</CFR>
+        <DEPDOC>[Docket No. PTO-P-2011-0065]</DEPDOC>
+        <RIN>RIN 0651-AC64</RIN>
+        <SUBJECT>Fee for Filing a Patent Application Other Than by the Electronic Filing System</SUBJECT>
+        <AGY>
+          <HD SOURCE="HED">AGENCY:</HD>
+          <P>United States Patent and Trademark Office, Commerce.</P>
+        </AGY>
+        <ACT>
+          <HD SOURCE="HED">ACTION:</HD>
+          <P>Final rule.</P>
+        </ACT>
+        <SUM>
+          <HD SOURCE="HED">SUMMARY:</HD>
+          <P>The Leahy-Smith America Invents Act provides an additional fee of $400 for applications not filed electronically. This final rule revises the rules of practice to include the fee for applications not filed electronically.</P>
+        </SUM>
+        <EFFDATE>
+          <HD SOURCE="HED">DATES:</HD>
+          <P>
+            <E T="03">Effective Date:</E> November 15, 2011.</P>
+        </EFFDATE>
+        <FURINF>
+          <HD SOURCE="HED">FOR FURTHER INFORMATION CONTACT:</HD>
+          <P>James J. Engel, Senior Legal Advisor, Office of Patent Legal Administration, Office of the Associate Commissioner for Patent Examination Policy, by telephone at (571) 272-7725; or by mail addressed to: Mail Stop Comments Patents, Commissioner for Patents, P.O. Box 1450, Alexandria, VA 22313-1450.</P>
+        </FURINF>
+      </PREAMB>
+      <SUPLINF>
+        <HD SOURCE="HED">SUPPLEMENTARY INFORMATION:</HD>
+
+        <P>Section 10(h) of the Leahy-Smith America Invents Act provides that an additional fee of $400 shall be established for each application for an original (<E T="03">i.e.,</E> non-reissue) patent, except for a design, plant, or provisional application, that is not filed by electronic means as prescribed by the Director of the United States Patent and Trademark Office (USPTO). <E T="03">See</E> Public Law 112-29, 125 Stat. 283, 319 (2011). Section 10(h) also provides that this fee is reduced by 50 percent for small entities under 35 U.S.C. 41(h)(1). <E T="03">See id.</E> Section 10(h) also provides that this new fee is effective on November 15, 2011 (sixty days after the date of enactment of the Leahy-Smith America Invents Act). <E T="03">See id.</E> This final rule revises 37 CFR 1.16 and 1.445 to include the fee for applications not filed electronically.</P>
+
+        <P>The USPTO encourages applicants to file their applications via its electronic filing system (EFS-Web) to avoid the fee provided for by section 10(h) of the Leahy-Smith America Invents Act. Information concerning electronic filing via EFS-Web is available from the USPTO's Patent Electronic Business Center (EBC) at <E T="03">http://www.uspto.gov/patents/process/file/efs/index.jsp.</E>
+          <PRTPAGE P="70652"/>
+        </P>
+        <HD SOURCE="HD1">Section-by-Section Discussion</HD>
+        <P>Title 37 of the Code of Federal Regulations, Part 1, is amended as follows:</P>
+        <P>
+          <E T="03">Section 1.16:</E> Section 1.16(t) is added to require the non-electronic filing fee of $400 ($200 for a small entity) for any application under 35 U.S.C. 111(a) (<E T="03">i.e.,</E> any nonprovisional application) that is filed on or after November 15, 2011, other than by the USPTO's electronic filing system (EFS-Web), except for a reissue, design, or plant application.</P>
+        <P>
+          <E T="03">Section 1.445:</E> The introductory text of § 1.445(a) is amended to add “by law or” prior to “by the Director under the authority of 35 U.S.C. 376” because the fee for filing an application other than by the USPTO's electronic filing system is established by law (section 10(h) of the Leahy-Smith America Invents Act). Section 1.445(a) is amended to set out the current transmittal fee as a basic fee in § 1.445(a)(1)(i) and to add a new § 1.445(a)(1)(ii) setting out the non-electronic filing fee of $400 ($200 for a small entity) for any Patent Cooperation Treaty (PCT) international application designating the United States of America that is filed on or after November 15, 2011, other than by the USPTO's electronic filing system (EFS-Web), except for a plant application. Section 1.445(a)(1)(ii) does not contain a reference to reissue, design, or provisional applications as these types of applications cannot be filed via the PCT. While § 1.445(a)(1)(ii) contains a reference to plant applications, the USPTO advises against filing a plant application under the PCT because many countries do not consider this subject matter to be patent-eligible, and the color drawings or color photographs that are often necessary for plant applications (§ 1.165(b)) are not permitted in PCT international applications (PCT Applicant's Guide (¶ 5.159) (Oct. 2011)).</P>
+        <P>The USPTO will consider applications filed with the USPTO via the Department of Defense Secret Internet Protocol Router Network (SIPRNET) as filed via the USPTO's electronic filing system for purposes of § 1.16(t) and § 1.445(a)(1)(ii).</P>
+        <HD SOURCE="HD1">Rule Making Considerations</HD>
+        <P>
+          <E T="03">A. Administrative Procedure Act (APA):</E> Section 10(h) of the Leahy-Smith America Invents Act provides that an additional fee of $400 ($200 for a small entity) shall be established for each application for an original (<E T="03">i.e.,</E> non-reissue) patent, except for a design, plant, or provisional application, that is not filed by electronic means as prescribed by the Director of the USPTO. The changes in this final rule simply reiterate the provisions of section 10(h) of the Leahy-Smith America Invents Act and are thus merely interpretative. <E T="03">See Gray Panthers Advocacy Comm.</E> v.<E T="03"> Sullivan,</E> 936 F.2d 1284, 1291-1292 (DC Cir. 1991) (regulation that reiterates statutory language does not require notice and comment procedures). Accordingly, prior notice and an opportunity for public comment are not required pursuant to 5 U.S.C. 553(b)(A) or any other law. <E T="03">See Cooper Techs. Co.</E> v.<E T="03"> Dudas,</E> 536 F.3d 1330, 1336-37 (Fed. Cir. 2008) (stating that 5 U.S.C. 553, and thus 35 U.S.C. 2(b)(2)(B), do not require notice and comment rule making for “interpretative rules, general statements of policy, or rules of agency organization, procedure, or practice.”) (quoting 5 U.S.C. 553(b)(A)). In addition, thirty-day advance publication is not required pursuant to 5 U.S.C. 553(d) or any other law. <E T="03">See</E> 5 U.S.C. 553(d) (requiring thirty-day advance publication for substantive rules).</P>
+        <P>
+          <E T="03">B. Regulatory Flexibility Act:</E> As prior notice and an opportunity for public comment are not required pursuant to 5 U.S.C. 553 or any other law, neither a regulatory flexibility analysis nor a certification under the Regulatory Flexibility Act (5 U.S.C. 601 <E T="03">et seq.</E>) is required. <E T="03">See</E> 5 U.S.C. 603.</P>
+        <P>
+          <E T="03">C. Executive Order 13132 (Federalism):</E> This rule making does not contain policies with federalism implications sufficient to warrant preparation of a Federalism Assessment under Executive Order 13132 (Aug. 4, 1999).</P>
+        <P>
+          <E T="03">D. Executive Order 12866 (Regulatory Planning and Review):</E> This rule making has been determined not to be significant for purposes of Executive Order 12866 (Sept. 30, 1993), as amended by Executive Order 13258 (Feb. 26, 2002) and Executive Order 13422 (Jan. 18, 2007).</P>
+        <P>
+          <E T="03">E. Executive Order 13563 (Improving Regulation and Regulatory Review):</E> The USPTO has complied with Executive Order 13563 (Jan. 18, 2011). Specifically, the USPTO has, to the extent feasible and applicable: (1) Made a reasoned determination that the benefits justify the costs of the rule; (2) tailored the rule to impose the least burden on society consistent with obtaining the regulatory objectives; (3) selected a regulatory approach that maximizes net benefits; (4) specified performance objectives; (5) identified and assessed available alternatives; (6) involved the public in an open exchange of information and perspectives among experts in relevant disciplines, affected stakeholders in the private sector, and the public as a whole, and provided on-line access to the rule making docket; (7) attempted to promote coordination, simplification, and harmonization across government agencies and identified goals designed to promote innovation; (8) considered approaches that reduce burdens and maintain flexibility and freedom of choice for the public; and (9) ensured the objectivity of scientific and technological information and processes.</P>
+        <P>
+          <E T="03">F. Executive Order 13175 (Tribal Consultation):</E> This rule making will not: (1) Have substantial direct effects on one or more Indian tribes; (2) impose substantial direct compliance costs on Indian tribal government; or (3) preempt tribal law. Therefore, a tribal summary impact statement is not required under Executive Order 13175 (Nov. 6, 2000).</P>
+        <P>
+          <E T="03">G. Executive Order 13211 (Energy Effect):</E> This rule making is not significant energy action under Executive Order 13211 because this rule making is not likely to have a significant adverse effect on the supply, distribution, or use of energy. Therefore, a Statement of Energy Effects is not required under Executive Order 13211 (May 18, 2001).</P>
+        <P>
+          <E T="03">H. Executive Order 12988 (Civil Justice Reform):</E> This rule making meets applicable standards to minimize litigation, eliminate ambiguity, and reduce burden as set forth in sections 3(a) and 3(b)(2) of Executive Order 12988 (Feb. 5, 1996).</P>
+        <P>
+          <E T="03">I. Executive Order 13045 (Protection of Children):</E> This rule making is not an economically significant rule and does not concern an environmental risk to health or safety that may disproportionately affect children under Executive Order 13045 (Apr. 21, 1997).</P>
+        <P>
+          <E T="03">J. Executive Order 12630 (Taking of Private Property):</E> This rule making will not effect a taking of private property or otherwise have taking implications under Executive Order 12630 (Mar. 15, 1988).</P>
+        <P>
+          <E T="03">K. Congressional Review Act:</E> Under the Congressional Review Act provisions of the Small Business Regulatory Enforcement Fairness Act of 1996 (5 U.S.C. 801 <E T="03">et seq.</E>), the USPTO will submit a report containing this final rule and other required information to the U.S. Senate, the U.S. House of Representatives, and the Comptroller General of the Government Accountability Office. The change in this rule making is not expected to result in an annual effect on the economy of 100 million dollars or more, a major increase in costs or prices, or significant adverse effects on competition, employment, investment, <PRTPAGE P="70653"/>productivity, innovation, or the ability of United States-based enterprises to compete with foreign-based enterprises in domestic and export markets. Therefore, this rule making is not expected to result in a “major rule” as defined in 5 U.S.C. 804(2).</P>
+        <P>
+          <E T="03">L. Unfunded Mandates Reform Act of 1995:</E> The changes proposed in this notice do not involve a Federal intergovernmental mandate that will result in the expenditure by State, local, and tribal governments, in the aggregate, of 100 million dollars (as adjusted) or more in any one year, or a Federal private sector mandate that will result in the expenditure by the private sector of 100 million dollars (as adjusted) or more in any one year, and will not significantly or uniquely affect small governments. Therefore, no actions are necessary under the provisions of the Unfunded Mandates Reform Act of 1995. <E T="03">See</E> 2 U.S.C. 1501 <E T="03">et seq.</E>
+        </P>
+        <P>
+          <E T="03">M. National Environmental Policy Act:</E> The rule making will not have any effect on the quality of the environment and is thus categorically excluded from review under the National Environmental Policy Act of 1968. See 42 U.S.C. 4321 <E T="03">et seq.</E>
+        </P>
+        <P>
+          <E T="03">N. National Technology Transfer and Advancement Act:</E> The requirements of section 12(d) of the National Technology Transfer and Advancement Act of 1995 (15 U.S.C. 272 note) are inapplicable, because this rule making does not involve the use of technical standards.</P>
+        <P>
+          <E T="03">O. Paperwork Reduction Act:</E> This rule making involves information collection requirements which are subject to review by the Office of Management and Budget (OMB) under the Paperwork Reduction Act of 1995 (44 U.S.C. 3501 <E T="03">et seq.</E>). As discussed previously, the changes in this final rule simply reiterate the provisions of section 10(h) of the Leahy-Smith America Invents Act. The collection of information involved in this rule making has been reviewed and previously approved by OMB under OMB control numbers 0651-0021 and 0651-0032. This notice does not add any additional information collection requirements for patent applicants or patentees. Therefore, the USPTO is not resubmitting information collection packages to OMB for its review and approval because the changes proposed in this notice do not affect the information collection requirements associated with the information collections under OMB control numbers 0651-0021 and 0651-0032. The USPTO will update fee calculations for the currently approved information collections associated with this rule making upon submission to the OMB of the renewals of those information collections.</P>
+        <P>Notwithstanding any other provision of law, no person is required to respond to, nor shall a person be subject to a penalty for failure to comply with, a collection of information subject to the requirements of the Paperwork Reduction Act unless that collection of information displays a currently valid OMB control number.</P>
+        <LSTSUB>
+          <HD SOURCE="HED">List of Subjects in 37 CFR Part 1</HD>
+          <P>Administrative practice and procedure, Courts, Freedom of information, Inventions and patents, Reporting and recordkeeping requirements, Small businesses, and Biologics.</P>
+        </LSTSUB>
+        
+        <P>For the reasons set forth in the preamble, 37 CFR part 1 is amended as follows:</P>
+        <REGTEXT PART="1" TITLE="37">
+          <PART>
+            <HD SOURCE="HED">PART 1—RULES OF PRACTICE IN PATENT CASES</HD>
+          </PART>
+          <AMDPAR>1. The authority citation for 37 CFR part 1 continues to read as follows:</AMDPAR>
+          <AUTH>
+            <HD SOURCE="HED">Authority:</HD>
+            <P>35 U.S.C. 2(b)(2), unless otherwise noted.</P>
+          </AUTH>
+        </REGTEXT>
+        <REGTEXT PART="1" TITLE="37">
+          <AMDPAR>2. Section 1.16 is amended by adding paragraph (t) to read as follows:</AMDPAR>
+          <SECTION>
+            <SECTNO>§ 1.16 </SECTNO>
+            <SUBJECT>National application filing, search, and examination fees.</SUBJECT>
+            <STARS/>
+            <P>(t) Non-electronic filing fee for any application under 35 U.S.C. 111(a) that is filed on or after November 15, 2011, other than by the Office electronic filing system, except for a reissue, design, or plant application:</P>
+            <GPOTABLE CDEF="s50,8" COLS="2" OPTS="L0,tp0,p1,8/9,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="01">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$200.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">By other than a small entity </ENT>
+                <ENT>$400.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <STARS/>
+          </SECTION>
+        </REGTEXT>
+        
+        <REGTEXT PART="1" TITLE="37">
+          <AMDPAR>3. Section 1.445 is amended by revising paragraph (a) introductory text and paragraph (a)(1) to read as follows:</AMDPAR>
+          <SECTION>
+            <SECTNO>§ 1.445 </SECTNO>
+            <SUBJECT>International application filing, processing and search fees.</SUBJECT>
+            <P>(a) The following fees and charges for international applications are established by law or by the Director under the authority of 35 U.S.C. 376:</P>
+            <P>(1) A transmittal fee (see 35 U.S.C. 361(d) and PCT Rule 14) consisting of:</P>
+            <GPOTABLE CDEF="s50,8" COLS="2" OPTS="L0,tp0,p1,8/9,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="01">(i) A basic portion </ENT>
+                <ENT>$240.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <P>(ii) A non-electronic filing fee portion for any international application designating the United States of America that is filed on or after November 15, 2011, other than by the Office electronic filing system, except for a plant application:</P>
+            <GPOTABLE CDEF="s50,8" COLS="2" OPTS="L0,tp0,p1,8/9,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="01">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$200.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">By other than a small entity </ENT>
+                <ENT>$400.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <STARS/>
+          </SECTION>
+        </REGTEXT>
+        <SIG>
+          <DATED>Dated: November 7, 2011.</DATED>
+          <NAME>David J. Kappos,</NAME>
+          <TITLE>Under Secretary of Commerce for Intellectual Property and Director of the United States Patent and Trademark Office.</TITLE>
+        </SIG>
+      </SUPLINF>
+      <FRDOC>[FR Doc. 2011-29462 Filed 11-14-11; 8:45 am]</FRDOC>
+      <BILCOD>BILLING CODE 3510-16-P</BILCOD>
+    </RULE>

--- a/documents/full_text/xml/2011/11/15/2011-29462.xml
+++ b/documents/full_text/xml/2011/11/15/2011-29462.xml
@@ -81,7 +81,7 @@
           <HD SOURCE="HED">List of Subjects in 37 CFR Part 1</HD>
           <P>Administrative practice and procedure, Courts, Freedom of information, Inventions and patents, Reporting and recordkeeping requirements, Small businesses, and Biologics.</P>
         </LSTSUB>
-        
+
         <P>For the reasons set forth in the preamble, 37 CFR part 1 is amended as follows:</P>
         <REGTEXT PART="1" TITLE="37">
           <PART>
@@ -118,7 +118,7 @@
             <STARS/>
           </SECTION>
         </REGTEXT>
-        
+
         <REGTEXT PART="1" TITLE="37">
           <AMDPAR>3. Section 1.445 is amended by revising paragraph (a) introductory text and paragraph (a)(1) to read as follows:</AMDPAR>
           <SECTION>
@@ -126,6 +126,7 @@
             <SUBJECT>International application filing, processing and search fees.</SUBJECT>
             <P>(a) The following fees and charges for international applications are established by law or by the Director under the authority of 35 U.S.C. 376:</P>
             <P>(1) A transmittal fee (see 35 U.S.C. 361(d) and PCT Rule 14) consisting of:</P>
+            <P>(i)</P>
             <GPOTABLE CDEF="s50,8" COLS="2" OPTS="L0,tp0,p1,8/9,g1,t1,i1">
               <TTITLE> </TTITLE>
               <BOXHD>
@@ -133,7 +134,7 @@
                 <CHED H="1"> </CHED>
               </BOXHD>
               <ROW>
-                <ENT I="01">(i) A basic portion </ENT>
+                <ENT I="01">A basic portion </ENT>
                 <ENT>$240.00</ENT>
               </ROW>
             </GPOTABLE>


### PR DESCRIPTION
There is an amendment in [FR 2011-29462](https://www.federalregister.gov/documents/2011/11/15/2011-29462/fee-for-filing-a-patent-application-other-than-by-the-electronic-filing-system) which includes an interim marker within a `GPOTABLE`, causing `regulations-parser` to be unable to derive paragraph depths.

Reproduction of the error can be accomplished using `regulations-parser`:

```bash
eregs clear
eregs preprocess_notice 2011-29462
eregs write_to output
```

The following change was introduced to [the source FR XML document](https://www.federalregister.gov/documents/full_text/xml/2011/11/15/2011-29462.xml):

1. For [37 CFR 1 amendment 3](https://www.federalregister.gov/d/2011-29462/p-amd-3), a paragraph node has been inserted before the `GPOTABLE` for § 1.445 (a)(1)(i), effectively pulling the marker out of the table.

This change enables the parser to correctly identify the paragraph depths and process the amendments.