### PR TITLE
FR 2013-06362 - enabling GPOTABLE depth interpretation

### DIFF
--- a/documents/full_text/xml/2013/03/20/2013-06362.xml
+++ b/documents/full_text/xml/2013/03/20/2013-06362.xml
@@ -137,7 +137,7 @@
           <CFR>37 CFR Part 41</CFR>
           <P>Administrative practice and procedure, Inventions and patents, Lawyers.</P>
         </LSTSUB>
-        
+
         <P>For the reasons set forth in the preamble, 37 CFR parts 1 and 41 are amended to read as follows:</P>
         <REGTEXT PART="1" TITLE="37">
           <PART>
@@ -148,7 +148,7 @@
             <HD SOURCE="HED">Authority:</HD>
             <P>35 U.S.C. 2(b)(2).</P>
           </AUTH>
-          
+
           <AMDPAR>2. Section 1.17 is revised to read as follows:</AMDPAR>
           <SECTION>
             <SECTNO>§ 1.17 </SECTNO>
@@ -446,13 +446,15 @@
             </GPOTABLE>
             <P>§ 1.217—for  processing a redacted copy of a paper submitted in the file of an application in which a redacted copy was submitted for the patent application publication.</P>
             <P>§ 1.221—for  requesting voluntary publication or republication of an application.</P>
-            <P>(j) [Reserved]</P>
             <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
               <TTITLE> </TTITLE>
               <BOXHD>
                 <CHED H="1"> </CHED>
                 <CHED H="1"> </CHED>
               </BOXHD>
+              <ROW>
+                <ENT>(j) [Reserved]</ENT>
+              </ROW>
               <ROW>
                 <ENT I="22">(k) For filing a request for expedited examination under § 1.155(a):</ENT>
               </ROW>
@@ -1049,7 +1051,7 @@
             <P> 35 U.S.C. 2(b)(2), 3(a)(2)(A), 21, 23, 32, 41, 134, 135, and Pub. L. 112-29.</P>
           </AUTH>
         </REGTEXT>
-        
+
         <REGTEXT PART="41" TITLE="37">
           <AMDPAR>7. Section 41.37 is amended by revising paragraphs (a) and (b) to read as follows:</AMDPAR>
           <SECTION>

--- a/documents/full_text/xml/2013/03/20/2013-06362.xml
+++ b/documents/full_text/xml/2013/03/20/2013-06362.xml
@@ -1,0 +1,1082 @@
+<RULE>
+      <PREAMB>
+        <AGENCY TYPE="N">DEPARTMENT OF COMMERCE</AGENCY>
+        <SUBAGY>United States Patent and Trademark Office</SUBAGY>
+        <CFR>37 CFR Parts 1 and 41</CFR>
+        <DEPDOC>[Docket No. PTO-C-2013-0010]</DEPDOC>
+        <RIN>RIN 0651-AC86</RIN>
+        <SUBJECT>Setting and Adjusting Patent Fees; Correction</SUBJECT>
+        <AGY>
+          <HD SOURCE="HED">AGENCY:</HD>
+          <P>United States Patent and Trademark Office, Department of Commerce.</P>
+        </AGY>
+        <ACT>
+          <HD SOURCE="HED">ACTION:</HD>
+          <P>Interim rule.</P>
+        </ACT>
+        <SUM>
+          <HD SOURCE="HED">SUMMARY:</HD>
+
+          <P>The United States Patent and Trademark Office (Office) is correcting final regulations that were published in the <E T="04">Federal Register</E> on January 18, 2013 (78 FR 4212) (“Fee Setting final rule”) to set and adjust patent fees as authorized by the Leahy-Smith America Invents Act (“AIA”). The Fee Setting rule became effective on March 19, 2013 (except that certain regulations relating to international applications become effective on January 1, 2014). This rulemaking corrects those final regulations to revise minor inconsistencies within the Fee Setting final rule or arising from other recent rulemakings under the AIA. It also corrects minor inconsistencies with a few of the Regulations under the Patent Cooperation Treaty (PCT) and typographical errors.</P>
+        </SUM>
+        <EFFDATE>
+          <HD SOURCE="HED">DATES:</HD>
+          <P>Effective March 20, 2013.</P>
+          <P>
+            <E T="03">Comment deadline date:</E> Written comments must be received on or before May 20, 2013.</P>
+        </EFFDATE>
+        <ADD>
+          <HD SOURCE="HED">ADDRESSES:</HD>
+
+          <P>Comments should be sent by electronic mail message over the Internet addressed to: <E T="03">AC86.comments@uspto.gov</E>. Comments may also be submitted by postal mail addressed to: Mail Stop Comments CFO, Office of the Chief Financial Officer, P.O. Box 1450, Alexandria, Virginia 22313-1450, marked to the attention of Michelle Picard, Office of the Chief Financial Officer.</P>
+
+          <P>Comments may also be sent by electronic mail message over the Internet via the Federal eRulemaking Portal. See the Federal eRulemaking Portal Web site (<E T="03">http://www.regulations.gov</E>) for additional instructions on providing comments via the Federal eRulemaking Portal.</P>
+          <P>Although comments may be submitted by postal mail, the Office prefers to receive comments by electronic mail message over the Internet because sharing comments with the public is more easily accomplished. Electronic comments are preferred to be submitted in plain text, but also may be submitted in ADOBE® portable document format or MICROSOFT WORD® format. Comments not submitted electronically should be submitted on paper in a format that facilitates convenient digital scanning into ADOBE® portable document format.</P>
+
+          <P>The comments will be available for public inspection at the Office of the Chief Financial Officer, currently located in Madison West, Tenth Floor, 600 Dulany Street, Alexandria, Virginia. Comments also will be available for viewing via the Office's Internet Web site (<E T="03">http://www.uspto.gov</E>). Because comments will be made available for public inspection, information that the submitter does not desire to make public, such as an address or phone number, should not be included in the comments.</P>
+        </ADD>
+        <FURINF>
+          <HD SOURCE="HED">FOR FURTHER INFORMATION CONTACT:</HD>
+
+          <P>Michelle Picard, Office of the Chief Financial Officer, by telephone at (571) 272-6354 or by email at <E T="03">michelle.picard@uspto.gov;</E> or Dianne Buie, Office of Planning and Budget, by telephone at (571) 272-6301 or by email at <E T="03">dianne.buie@uspto.gov</E>.</P>
+        </FURINF>
+      </PREAMB>
+      <SUPLINF>
+        <HD SOURCE="HED">SUPPLEMENTARY INFORMATION:</HD>
+
+        <P>On January 18, 2013, the Office published the Fee Setting final rule setting and adjusting patent fees as authorized by the AIA. <E T="03">See Setting and Adjusting Patent Fees,</E> 78 FR 4212 (Jan. 18, 2013) (“Fee Setting final rule”). This interim rule is a procedural correction to minor inconsistencies within the Fee Setting final rule or arising from other recent rulemakings under the AIA, namely: Changes to Implement the First Inventor to File Provisions of the Leahy-Smith America Invents Act, 78 FR 11024 (Feb. 14, 2013) (“FITF final rule”); Changes to Implement Micro Entity Status for Paying Patent Fees, 77 FR 75019 (Dec. 19, 2012) (“Micro Entity final rule”); Changes to Implement the Inventor's Oath or Declaration Provisions of the Leahy-Smith America Invents Act, 77 FR 48776 (Aug. 14, 2012) (“Inventor's Oath or Declaration final rule”); and Changes to Implement the Preissuance Submissions by Third Parties Provision of the Leahy-Smith America Invents Act, 77 FR 42150 (July 17, 2012) (“Third Party Submissions final rule”). It also corrects minor inconsistencies with the nomenclature and application of a few of the Regulations under the Patent Cooperation Treaty, as well as typographical errors. Good cause exists to make these minor corrections without prior notice and opportunity for comment and to be effective shortly after the effective date of the Fee Setting final rule to avoid inconsistent provisions. For ease of reference, this interim rule provides the full text of the corrected rules. These rules are 37 CFR 1.17, 1.20, 1.445, 1.482, 41.37 and 41.45.</P>
+        <HD SOURCE="HD1">Brief Description of Corrections</HD>
+
+        <P>This interim rule corrects minor inconsistencies and typographical errors in the text of 37 CFR 1.17, 1.20, 1.445, 1.482, 41.37 and 41.45 (which were published in the <E T="04">Federal Register</E> on January 18, 2013 (78 FR 4212)), as described briefly below.</P>
+        <HD SOURCE="HD2">1. Section 1.17</HD>
+
+        <P>In paragraph (b), revise “For fees in proceedings before the Patent Trial and Appeal Board, <E T="03">see</E> § 41.20 of this title” to “For fees in proceedings before the Patent Trial and Appeal Board, <E T="03">see</E> § 41.20 and § 42.15 of this title” to correct a typographical error in the Fee Setting final rule. <E T="03">See</E> 78 FR 4285.</P>
+
+        <P>In paragraph (g), add “§ 1.46—for filing an application on behalf of an inventor by a person who otherwise shows sufficient proprietary interest in the matter” and “§ 1.55(f)—for filing a belated certified copy of a foreign application.” These corrections are made because the FITF final rule established these fees under this paragraph. <E T="03">See</E> 78 FR 11052.</P>
+
+        <P>In paragraph (g), delete “§ 1.47—for filing by other than all the inventors or a person not the inventor.” This correction is made because the Inventor's Oath or Declaration final rule removed this fee. <E T="03">See</E> 77 FR 48816.</P>
+
+        <P>In paragraph (g), delete “§ 1.295—for review of refusal to publish a statutory invention registration” and “§ 1.296—to withdraw a request for publication of a statutory invention registration filed on or after the date the notice of intent to publish issued.” These corrections are made because the FITF final rule removed these fees. <E T="03">See</E> 78 FR 11059.</P>
+
+        <P>In subparagraph (i)(1), add “§ 1.29(k)(3)—for processing a non-itemized fee deficiency based on an error in micro entity status.” This correction is made because the Micro-<PRTPAGE P="17103"/>Entity final rule established this fee under this paragraph. <E T="03">See</E> 77 FR 75035.</P>
+
+        <P>In subparagraph (i)(1), revise “§ 1.41—for supplying the name or names of the inventor or inventors after the filing date without an oath or declaration as prescribed by § 1.63, except in provisional applications” to “§ 1.41(b)—for supplying the name or names of the inventor or joint inventors in an application without either an application data sheet or the inventor's oath or declaration, except in provisional applications.” This correction is made because the Inventor's Oath or Declaration final rule established this fee under this subparagraph. <E T="03">See</E> 77 FR 48814.</P>
+
+        <P>In subparagraph (i)(1), revise “§ 1.53(b)(3)” to “§ 1.53(c)(3)” to correct a typographical error in the Fee Setting final rule. <E T="03">See</E> 78 FR 4286.</P>
+
+        <P>In subparagraph (i)(1), revise “§ 1.55—for entry of late priority papers” to “§ 1.55—for entry of a priority claim or certified copy of a foreign application after payment of the issue fee.” This correction is made because the FITF final rule established this fee under this paragraph. <E T="03">See</E> 78 FR 11052.</P>
+
+        <P>In subparagraph (i)(1), delete “§ 1.99(e)—for processing a belated submission under § 1.99.” This correction is made because the Third Party Submissions final rule removed this fee. <E T="03">See</E> 77 FR 42173.</P>
+
+        <P>In subparagraph (i)(1), delete “§ 1.497(d)—for filing an oath or declaration pursuant to 35 U.S.C. 371(c)(4) naming an inventive entity different from the inventive entity set forth in the international stage.” This correction is made because the Inventor's Oath or Declaration final rule removed this fee. <E T="03">See</E> 77 FR 48824-25.</P>
+
+        <P>In subparagraph (i)(2), delete “By other than a small or micro entity.” This correction addresses a typographical error in the Fee Setting final rule. <E T="03">See</E> 78 FR 4267, Table 43.</P>
+        <HD SOURCE="HD2">2. Section 1.20</HD>
+
+        <P>In paragraph (d), delete “By other than a small or micro entity.” This correction addresses a typographical error in the Fee Setting final rule. <E T="03">See</E> 78 FR 4223.</P>
+        <HD SOURCE="HD2">3. Section 1.445</HD>
+        <P>In subparagraph (a)(1)(i)(A), revise “For a transmittal fee paid on or after January 1, 2014” to “For an international application having a receipt date that is on or after January 1, 2014.” In subparagraph (a)(1)(i)(B), revise “For a transmittal fee paid before January 1, 2014” to “For an international application having a receipt date that is before January 1, 2014.”</P>
+        <P>In subparagraph (a)(2)(i), revise “For a search fee paid on or after January 1, 2014” to “For an international application having a receipt date that is on or after January 1, 2014.” In subparagraph (a)(2)(ii), revise “For a search fee paid before January 1, 2014” to “For an international application having a receipt date that is before January 1, 2014.”</P>
+        <P>In subparagraph (a)(3)(i), revise “For a supplemental search fee paid on or after January 1, 2014” to “For an international application having a receipt date that is on or after January 1, 2014.” In subparagraph (a)(3)(ii), revise “For a supplemental search fee paid before January 1, 2014” to “For an international application having a receipt date that is before January 1, 2014.”</P>
+        <P>The foregoing corrections ensure consistent nomenclature with and application of Rules 14-16 under the regulations adopted under the Patent Cooperation Treaty.</P>
+
+        <P>In subparagraph (a)(4), delete 1.445(a)(4)(i) and 1.445(a)(4)(ii). This corrects an inconsistency within 37 CFR § 1.445(a)(4) in the Fee Setting final rule. <E T="03">See</E> 78 FR 4289.</P>
+        <HD SOURCE="HD2">4. Section 1.482</HD>
+        <P>In subparagraph (a)(1)(i)(A), revise “For an international search fee filed on or after January 1, 2014” to “For an international preliminary examination fee paid on or after January 1, 2014.” In subparagraph (a)(1)(i)(B), revise “For an international search fee filed before January 1, 2014” to “For an international preliminary examination fee paid before January 1, 2014.”</P>
+        <P>In subparagraph (a)(1)(ii)(A), revise “For an international search fee filed on or after January 1, 2014” to “For an international preliminary examination fee paid on or after January 1, 2014.” In subparagraph (a)(1)(ii)(B), revise “For an international search fee filed before January 1, 2014” to “For an international preliminary examination fee paid before January 1, 2014.”</P>
+        <P>In subparagraph (a)(2)(i), revise “For an additional preliminary examination fee filed on or after January 1, 2014” to “If the international preliminary examination fee set forth in paragraph (a)(1) of this section was paid on or after January 1, 2014.” In subparagraph (a)(2)(ii), revise “For an additional preliminary examination fee filed before January 1, 2014” to “If the international preliminary examination fee set forth in paragraph (a)(1) of this section was paid before January 1, 2014.”</P>
+        <P>The foregoing corrections ensure consistent nomenclature with and application of Rules 57 and 58 under the regulations adopted under the Patent Cooperation Treaty.</P>
+        <HD SOURCE="HD2">5. Section 41.37</HD>
+
+        <P>In paragraph (a), second sentence, replace “§ 41.48” with “§ 41.45” to correct a typographical error in the Fee Setting final rule. <E T="03">See</E> 78 FR 4291.</P>
+        <HD SOURCE="HD2">6. Section 41.45</HD>
+
+        <P>In paragraph (b), add “to pay the” so that the provision reads “On failure to pay the fee set forth in * * *.” This corrects a typographical error in the Fee Setting final rule. <E T="03">See</E> 78 FR 4291.</P>
+        <HD SOURCE="HD1">Rulemaking Considerations</HD>
+        <P>
+          <E T="03">A. Administrative Procedure Act:</E> This rulemaking is a procedural correction to revise minor inconsistencies within the Fee Setting final rule or arising from other recent rulemakings under the AIA, namely: The FITF final rule; the Micro Entity final rule; the Inventor's Oath or Declaration final rule; and the Third Party Submissions final rule. It also corrects minor inconsistencies with the nomenclature and application of a few of the Regulations under the Patent Cooperation Treaty, as well as typographical errors. This interim rule does not set or adjust fees under the fee setting authority provided in Section 10 of the AIA. These changes do not alter the amount of fees or the obligation to pay fees, nor do they alter the substantive criteria of patentability or patent term adjustment. Therefore, these changes involve rules of agency practice and procedure, and are not subject to prior notice and an opportunity for comment. <E T="03">See</E> 5 U.S.C. 553(b); <E T="03">see also Bachow Commc'ns, Inc.</E> v.<E T="03"> F.C.C.,</E> 237 F.3d 683, 690 (D.C. Cir. 2001) (rules governing an application process are procedural under the Administrative Procedure Act).</P>
+        <P>In addition, good cause exists to make these procedural changes without prior notice and opportunity for comment and to be effective immediately to avoid inconsistencies and confusion with the Fee Setting final rule.</P>
+        <P>Although prior notice and opportunity for public comment are not required pursuant to 5 U.S.C. 553(b) or (c) (or any other law), nor is the thirty-day delay in effectiveness under 5 U.S.C. 553(d) required, the Office nonetheless provides the opportunity for comment as it seeks the benefit of the public's views on these corrections to the Fee Setting final rule.</P>
+        <P>
+          <E T="03">B. Regulatory Flexibility Act:</E> For the reasons set forth herein, the Deputy General Counsel for General Law of the <PRTPAGE P="17104"/>United States Patent and Trademark Office has certified to the Chief Counsel for Advocacy of the Small Business Administration that changes in this rulemaking will not have a significant economic impact on a substantial number of small entities. <E T="03">See</E> 5 U.S.C. 605(b).</P>
+        <P>The changes in this rulemaking are procedural corrections to revise minor inconsistencies within the Fee Setting final rule or arising from other recent rulemakings under the AIA. This rulemaking also corrects minor inconsistencies with the nomenclature and application of a few of the Regulations under the Patent Cooperation Treaty, as well as typographical errors. This interim rule does not set or adjust fees under the fee setting authority provided in Section 10 of the AIA. These changes do not alter the amount of fees or the obligation to pay fees, nor do they alter the substantive criteria of patentability or patent term adjustment. These changes do not add any additional requirements (including information collection requirements) or fees for patent applicants or patentees. For these reasons, the changes in this rulemaking will not have a significant economic impact on a substantial number of small entities.</P>
+        <P>
+          <E T="03">C. Executive Order 12866 (Regulatory Planning and Review):</E> This rulemaking has been determined to be not significant for purposes of Executive Order 12866 (Sept. 30, 1993).</P>
+        <P>
+          <E T="03">D. Executive Order 13563 (Improving Regulation and Regulatory Review):</E> The Office has complied with Executive Order 13563. Specifically, the Office has, to the extent feasible and applicable: (1) Made a reasoned determination that the benefits justify the costs of the rule; (2) tailored the rule to impose the least burden on society consistent with obtaining the regulatory objectives; (3) selected a regulatory approach that maximizes net benefits; (4) specified performance objectives; (5) identified and assessed available alternatives; (6) involved the public in an open exchange of information and perspectives among experts in relevant disciplines, affected stakeholders in the private sector and the public as a whole, and provided on-line access to the rulemaking docket; (7) attempted to promote coordination, simplification, and harmonization across government agencies and identified goals designed to promote innovation; (8) considered approaches that reduce burdens and maintain flexibility and freedom of choice for the public; and (9) ensured the objectivity of scientific and technological information and processes.</P>
+        <P>
+          <E T="03">E. Executive Order 13132 (Federalism):</E> This rulemaking does not contain policies with federalism implications sufficient to warrant preparation of a Federalism Assessment under Executive Order 13132 (Aug. 4, 1999).</P>
+        <P>
+          <E T="03">F. Executive Order 13175 (Tribal Consultation):</E> This rulemaking will not: (1) Have substantial direct effects on one or more Indian tribes; (2) impose substantial direct compliance costs on Indian tribal governments; or (3) preempt tribal law. Therefore, a tribal summary impact statement is not required under Executive Order 13175 (Nov. 6, 2000).</P>
+        <P>
+          <E T="03">G. Executive Order 13211 (Energy Effects):</E> This rulemaking is not a significant energy action under Executive Order 13211 because this rulemaking is not likely to have a significant adverse effect on the supply, distribution, or use of energy. Therefore, a Statement of Energy Effects is not required under Executive Order 13211 (May 18, 2001).</P>
+        <P>
+          <E T="03">H. Executive Order 12988 (Civil Justice Reform):</E> This rulemaking meets applicable standards to minimize litigation, eliminate ambiguity, and reduce burden as set forth in sections 3(a) and 3(b)(2) of Executive Order 12988 (Feb. 5, 1996).</P>
+        <P>
+          <E T="03">I. Executive Order 13045 (Protection of Children):</E> This rulemaking does not concern an environmental risk to health or safety that may disproportionately affect children under Executive Order 13045 (Apr. 21, 1997).</P>
+        <P>
+          <E T="03">J. Executive Order 12630 (Taking of Private Property):</E> This rulemaking will not affect a taking of private property or otherwise have taking implications under Executive Order 12630 (Mar. 15, 1988).</P>
+        <P>
+          <E T="03">K. Congressional Review Act:</E> Under the Congressional Review Act provisions of the Small Business Regulatory Enforcement Fairness Act of 1996 (5 U.S.C. 801 <E T="03">et seq.</E>), prior to issuing any final rule, the United States Patent and Trademark Office will submit a report containing the final rule and other required information to the United States Senate, the United States House of Representatives, and the Comptroller General of the Government Accountability Office.</P>
+        <P>The changes in this rulemaking are not expected to result in an annual effect on the economy of 100 million dollars or more, a major increase in costs or prices, or significant adverse effects on competition, employment, investment, productivity, innovation, or the ability of United States-based enterprises to compete with foreign-based enterprises in domestic and export markets. Therefore, this rulemaking is not expected to result in a “major rule” as defined in 5 U.S.C. 804(2).</P>
+        <P>
+          <E T="03">L. Unfunded Mandates Reform Act of 1995:</E> The changes set forth in this rulemaking do not involve a Federal intergovernmental mandate that will result in the expenditure by State, local, and tribal governments, in the aggregate, of 100 million dollars (as adjusted) or more in any one year, or a Federal private sector mandate that will result in the expenditure by the private sector of 100 million dollars (as adjusted) or more in any one year, and will not significantly or uniquely affect small governments. Therefore, no actions are necessary under the provisions of the Unfunded Mandates Reform Act of 1995. <E T="03">See</E> 2 U.S.C. 1501 <E T="03">et seq.</E>
+        </P>
+        <P>
+          <E T="03">M. National Environmental Policy Act:</E> This rulemaking will not have any effect on the quality of the environment and is thus categorically excluded from review under the National Environmental Policy Act of 1969. <E T="03">See</E> 42 U.S.C. 4321 <E T="03">et seq.</E>
+        </P>
+        <P>
+          <E T="03">N. National Technology Transfer and Advancement Act:</E> The requirements of section 12(d) of the National Technology Transfer and Advancement Act of 1995 (15 U.S.C. 272 note) are not applicable because this rulemaking does not contain provisions which involve the use of technical standards.</P>
+        <P>
+          <E T="03">O. Paperwork Reduction Act:</E> The Paperwork Reduction Act of 1995 (44 U.S.C. 3501 <E T="03">et seq.</E>) requires that the Office consider the impact of paperwork and other information collection burdens imposed on the public. The collection of information involved in the Fee Setting final rule was submitted to OMB with that final rule as a new information collection request and was preapproved under OMB control number 0651-0072. The changes in this interim rule are procedural corrections to revise minor inconsistencies within the Fee Setting final rule or arising from other recent rulemakings under the AIA. This rulemaking also corrects minor inconsistencies with the nomenclature and application of a few of the Regulations under the Patent Cooperation Treaty, as well as typographical errors. This interim rule does not set or adjust fees under the fee setting authority provided in Section 10 of the AIA. These changes do not alter the amount of fees or the obligation to pay fees, nor do they alter the substantive criteria of patentability or patent term adjustment. These changes do not add any additional requirements (including information collection <PRTPAGE P="17105"/>requirements) or fees for patent applicants or patentees. Therefore, the Office is not resubmitting information collection packages to OMB for its review and approval because the changes in this rulemaking do not affect the information collection requirements associated with the information collections approved under OMB control number 0651-0072 or any other information collections.</P>
+        <P>Notwithstanding any other provision of law, no person is required to respond to nor shall any person be subject to a penalty for failure to comply with a collection of information subject to the requirements of the Paperwork Reduction Act unless that collection of information displays a currently valid OMB control number.</P>
+        <LSTSUB>
+          <HD SOURCE="HED">List of Subjects</HD>
+          <CFR>37 CFR Part 1</CFR>
+          <P>Administrative practice and procedure, Courts, Freedom of information, Inventions and patents, Reporting and recordkeeping requirements, Small businesses.</P>
+          <CFR>37 CFR Part 41</CFR>
+          <P>Administrative practice and procedure, Inventions and patents, Lawyers.</P>
+        </LSTSUB>
+        
+        <P>For the reasons set forth in the preamble, 37 CFR parts 1 and 41 are amended to read as follows:</P>
+        <REGTEXT PART="1" TITLE="37">
+          <PART>
+            <HD SOURCE="HED">PART 1—RULES OF PRACTICE IN PATENT CASES</HD>
+          </PART>
+          <AMDPAR>1. The authority citation for 37 CFR part 1 continues to read as follows:</AMDPAR>
+          <AUTH>
+            <HD SOURCE="HED">Authority:</HD>
+            <P>35 U.S.C. 2(b)(2).</P>
+          </AUTH>
+          
+          <AMDPAR>2. Section 1.17 is revised to read as follows:</AMDPAR>
+          <SECTION>
+            <SECTNO>§ 1.17 </SECTNO>
+            <SUBJECT>Patent application and reexamination processing fees.</SUBJECT>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="22">(a) Extension fees pursuant to § 1.136(a):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(1) For reply within first month:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$50.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$100.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$200.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(2) For reply within second month:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$150.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$300.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$600.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(3) For reply within third month:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$350.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$700.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$1,400.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">(4) For reply within fourth month:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$550.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$1,100.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$2,200.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(5) For reply within fifth month:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$750.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$1,500.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$3,000.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(b) For fees in proceedings before the Patent Trial and Appeal Board, <E T="03">see</E> § 41.20 and § 42.15 of this title.</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(c) For filing a request for prioritized examination under § 1.102(e):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$1,000.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$2,000.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$4,000.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(d) For correction of inventorship in an application after the first action on the merits:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$150.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$300.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$600.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(e) To request continued examination pursuant to § 1.114:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(1) For filing a first request for continued examination pursuant to § 1.114 in an application:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$300.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$600.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$1,200.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(2) For filing a second or subsequent request for continued examination pursuant to § 1.114 in an application:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$425.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$850.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$1,700.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(f) For filing a petition under one of the following sections which refers to this paragraph:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$100.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$200.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$400.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <P>§ 1.36(a)—for revocation of a power of attorney by fewer than all of the applicants.</P>
+            <P>§ 1.53(e)—to accord a filing date.</P>
+            <P>§ 1.57(a)—to accord a filing date.</P>
+            <P>§ 1.182—for decision on a question not specifically provided for.</P>
+            <P>§ 1.183—to suspend the rules.</P>
+            <P>§ 1.378(e)—for reconsideration of decision on petition refusing to accept delayed payment of maintenance fee in an expired patent.</P>
+            <P>§ 1.741(b)—to accord a filing date to an application under § 1.740 for extension of a patent term.</P>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="22">(g) For filing a petition under one of the following sections which refers to this paragraph:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$50.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$100.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$200.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <P>§ 1.12—for  access to an assignment record.</P>
+            <P>§ 1.14—for  access to an application.</P>
+            <P>§ 1.46—for  filing an application on behalf of an inventor by a person who otherwise shows sufficient proprietary interest in the matter.</P>
+            <P>§ 1.55(f)—for  filing a belated certified copy of a foreign application.</P>
+            <P>§ 1.59—for  expungement of information.</P>
+            <P>§ 1.103(a)—to  suspend action in an application.</P>
+            <P>§ 1.136(b)—for  review of a request for extension of time when the provisions of § 1.136(a) are not available.</P>
+            <P>§ 1.377—for  review of decision refusing to accept and record payment of a maintenance fee filed prior to expiration of a patent.</P>
+
+            <P>§ 1.550(c)—for  patent owner requests for extension of time in <E T="03">ex parte</E> reexamination proceedings.</P>
+
+            <P>§ 1.956—for  patent owner requests for extension of time in <E T="03">inter partes</E> reexamination proceedings.</P>
+            <P>§ 5.12—for  expedited handling of a foreign filing license.</P>
+            <P>§ 5.15—for  changing the scope of a license.</P>
+            <P>§ 5.25—for  retroactive license.</P>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="22">(h) For filing a petition under one of the following sections which refers to this paragraph:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$35.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$70.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$140.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <P>§ 1.19(g)—to  request documents in a form other than provided in this part.</P>
+            <P>§ 1.84—for  accepting color drawings or photographs.</P>
+            <P>§ 1.91—for  entry of a model or exhibit.</P>
+            <P>§ 1.102(d)—to  make an application special.</P>
+            <P>§ 1.138(c)—to  expressly abandon an application to avoid publication.</P>
+            <P>§ 1.313—to  withdraw an application from issue.</P>
+            <P>§ 1.314—to  defer issuance of a patent.</P>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="22">(i) Processing fees:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(1) For taking action under one of the following sections which refers to this paragraph:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$35.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$70.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$140.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <P>§ 1.28(c)(3)—for  processing a non-itemized fee deficiency based on an error in small entity status.</P>
+            <P>§ 1.29(k)(3)—for  processing a non-itemized fee deficiency based on an error in micro entity status.</P>
+            <P>§ 1.41(b)—for  supplying the name or names of the inventor or joint inventors in an application without either an application data sheet or the inventor's oath or declaration, except in provisional applications.</P>
+            <P>§ 1.48—for  correcting inventorship, except in provisional applications.</P>
+            <P>§ 1.52(d)—for  processing a nonprovisional application filed with a specification in a language other than English.</P>
+            <P>§ 1.53(c)(3)—to  convert a provisional application filed under § 1.53(c) into a nonprovisional application under § 1.53(b).</P>
+
+            <P>§ 1.55—for  entry of a priority claim or certified copy of a foreign application after payment of the issue fee.<PRTPAGE P="17106"/>
+            </P>
+            <P>§ 1.71(g)(2)—for  processing a belated amendment under § 1.71(g).</P>
+            <P>§ 1.102(e)—for  requesting prioritized examination of an application.</P>
+            <P>§ 1.103(b)—for  requesting limited suspension of action, continued prosecution application for a design patent (§ 1.53(d)).</P>
+            <P>§ 1.103(c)—for  requesting limited suspension of action, request for continued examination (§ 1.114).</P>
+            <P>§ 1.103(d)—for  requesting deferred examination of an application.</P>
+            <P>§ 1.291(c)(5)—for  processing a second or subsequent protest by the same real party in interest.</P>
+            <P>§ 3.81—for  a patent to issue to assignee, assignment submitted after payment of the issue fee.</P>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="02">(2) For taking action under one of the following sections which refers to this paragraph</ENT>
+                <ENT>$130.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <P>§ 1.217—for  processing a redacted copy of a paper submitted in the file of an application in which a redacted copy was submitted for the patent application publication.</P>
+            <P>§ 1.221—for  requesting voluntary publication or republication of an application.</P>
+            <P>(j) [Reserved]</P>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="22">(k) For filing a request for expedited examination under § 1.155(a):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$225.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$450.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity. </ENT>
+                <ENT>$900.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(l) For filing a petition for the revival of an unavoidably abandoned application under 35 U.S.C. 111, 133, 364, or 371, for the unavoidably delayed payment of the issue fee under 35 U.S.C. 151, or for the revival of an unavoidably terminated reexamination proceeding under 35 U.S.C. 133 (§ 1.137(a)):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$160.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$320.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity </ENT>
+                <ENT>$640.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(m) For filing a petition for the revival of an unintentionally abandoned application, for the unintentionally delayed payment of the fee for issuing a patent, or for the revival of an unintentionally terminated reexamination proceeding under 35 U.S.C. 41(a)(7) (§ 1.137(b)):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$475.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$950.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$1,900.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(n) [Reserved]</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(o) [Reserved]</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(p) For an information disclosure statement under § 1.97(c) or (d) or for the document fee for a submission under § 1.290:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$45.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$90.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$180.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(q) Processing fee for taking action under one of the following sections which refers to this paragraph </ENT>
+                <ENT>$50.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <P>§ 1.41—to  supply the name or names of the inventor or inventors after the filing date without a cover sheet as prescribed by § 1.51(c)(1) in a provisional application.</P>
+            <P>§ 1.48—for  correction of inventorship in a provisional application.</P>
+            <P>§ 1.53(c)(2)—to convert a nonprovisional application filed under § 1.53(b) to a provisional application under § 1.53(c).</P>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="22">(r) For entry of a submission after final rejection under § 1.129(a):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$210.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$420.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity </ENT>
+                <ENT>$840.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(s) For each additional invention requested to be examined under § 1.129(b):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$210.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$420.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity </ENT>
+                <ENT>$840.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(t) For the acceptance of an unintentionally delayed claim for priority under 35 U.S.C. 119, 120, 121, or 365(a) or (c) (§§ 1.55 and 1.78) or for filing a request for the restoration of the right of priority under § 1.452:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$355.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)). </ENT>
+                <ENT>$710.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity </ENT>
+                <ENT>$1,420.00</ENT>
+              </ROW>
+            </GPOTABLE>
+          </SECTION>
+        </REGTEXT>
+        <REGTEXT PART="1" TITLE="37">
+          <AMDPAR>3. Section 1.20 is revised to read as follows:</AMDPAR>
+          <SECTION>
+            <SECTNO>§ 1.20 </SECTNO>
+            <SUBJECT>Post issuance fees.</SUBJECT>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="2"> </CHED>
+                <CHED H="2"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="01">(a) For providing a certificate of correction for applicant's mistake  (§ 1.323)</ENT>
+                <ENT>$100.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(b) Processing fee for correcting inventorship in a patent (§ 1.324) </ENT>
+                <ENT>$130.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(c) In reexamination proceedings:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(1) For filing a request for <E T="03">ex parte</E> reexamination (§ 1.510(a)):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$3,000.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$6,000.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$12,000.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(2) [Reserved]</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(3) For filing with a request for reexamination or later presentation at any other time of each claim in independent form in excess of 3 and also in excess of the number of claims in independent form in the patent under reexamination:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$105.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$210.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$420.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(4) For filing with a request for reexamination or later presentation at any other time of each claim (whether dependent or independent) in excess of 20 and also in excess of the number of claims in the patent under reexamination (note that § 1.75(c) indicates how multiple dependent claims are considered for fee calculation purposes):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$20.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$40.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$80.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(5) If the excess claims fees required by paragraphs (c)(3) and (4) of this section are not paid with the request for reexamination or on later presentation of the claims for which the excess claims fees are due, the fees required by paragraphs (c)(3) and (4) must be paid or the claims canceled by amendment prior to the expiration of the time period set for reply by the Office in any notice of fee deficiency in order to avoid abandonment.</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(6) For filing a petition in a reexamination proceeding, except for those specifically enumerated in §§ 1.550(i) and 1.937(d):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$485.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$970.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$1,940.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(7) For a refused request for <E T="03">ex parte</E> reexamination under § 1.510 (included in the request for <E T="03">ex parte</E> reexamination fee at § 1.20(c)(1)):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$900.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$1,800.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$3,600.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(d) For filing each statutory disclaimer (§ 1.321) </ENT>
+                <ENT>$160.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(e) For maintaining an original or reissue patent, except a design or plant patent, based on an application filed on or after December 12, 1980, in force beyond four years, the fee being due by three years and six months after the original grant:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$400.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$800.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$1,600.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(f) For maintaining an original or reissue patent, except a design or plant patent, based on an application filed on or after December 12, 1980, in force beyond eight years, the fee being due by seven years and six months after the original grant:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$900.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$1,800.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$3,600.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(g) For maintaining an original or reissue patent, except a design or plant patent, based on an application filed on or after December 12, 1980, in force beyond twelve years, the fee being due by eleven years and six months after the original grant:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$1,850.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$3,700.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$7,400.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(h) Surcharge for paying a maintenance fee during the six-month grace period following the expiration of three years and six months, seven years and six months, and eleven years and six months after the date of the original grant of a patent based on an application filed on or after December 12, 1980:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$40.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$80.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$160.00</ENT>
+              </ROW>
+              <ROW>
+                <PRTPAGE P="17107"/>
+                <ENT I="22">(i) Surcharge for accepting a maintenance fee after expiration of a patent for non-timely payment of a maintenance fee where the delay in payment is shown to the satisfaction of the Director to have been—</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(1) Unavoidable:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$175.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$350.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$700.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(2) Unintentional:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$410.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$820.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$1,640.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(j) For filing an application for extension of the term of a patent</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">Application for extension under § 1.740</ENT>
+                <ENT>$1,120.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">Initial application for interim extension under § 1.790</ENT>
+                <ENT>$420.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">Subsequent application for interim extension under § 1.790</ENT>
+                <ENT>$220.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(k) In supplemental examination proceedings:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(1) For processing and treating a request for supplemental examination:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$1,100.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$2,200.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$4,400.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(2) For <E T="03">ex parte</E> reexamination ordered as a result of a supplemental examination proceeding:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$3,025.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$6,050.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$12,100.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(3) For processing and treating, in a supplemental examination proceeding, a non-patent document over 20 sheets in length, per document:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(i) Between 21 and 50 sheets:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$45.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$90.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity.</ENT>
+                <ENT>$180.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(ii) For each additional 50 sheets or a fraction thereof:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$70.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$140.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$280.00</ENT>
+              </ROW>
+            </GPOTABLE>
+          </SECTION>
+        </REGTEXT>
+        <REGTEXT PART="1" TITLE="37">
+          <AMDPAR>4. Section 1.445 is revised to read as follows:</AMDPAR>
+          <SECTION>
+            <SECTNO>§ 1.445 </SECTNO>
+            <SUBJECT>International application filing, processing and search fees.</SUBJECT>
+            <P>(a) The following fees and charges for international applications are established by law or by the Director under the authority of 35 U.S.C. 376:</P>
+            <P>(1) A transmittal fee (<E T="03">see</E> 35 U.S.C. 361(d) and PCT Rule 14) consisting of:</P>
+            <P>(i) A basic portion:</P>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="22">(A) For an international application having a receipt date that is on or after January 1, 2014:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$60.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$120.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$240.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(B) For an international application having a receipt date that is before January 1, 2014</ENT>
+                <ENT>$240.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(ii) A non-electronic filing fee portion for any international application designating the United States of America that is filed on or after November 15, 2011, other than by the Office electronic filing system, except for a plant application:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$200.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small entity </ENT>
+                <ENT>$400.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(2) A search fee (<E T="03">see</E> 35 U.S.C. 361(d) and PCT Rule 16):</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(i) For an international application having a receipt date that is on or after January 1, 2014:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$520.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$1,040.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$2,080.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(ii) For an international application having a receipt date that is before January 1, 2014 </ENT>
+                <ENT>$2,080.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(3) A supplemental search fee when required, per additional invention:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(i) For an international application having a receipt date that is on or after January 1, 2014:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29) </ENT>
+                <ENT>$520.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$1,040.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$2,080.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(ii) For an international application having a receipt date that is before January 1, 2014 </ENT>
+                <ENT>$2,080.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <P>(4) A fee equivalent to the transmittal fee in paragraph (a)(1) of this section that would apply if the USPTO was the Receiving Office for transmittal of an international application to the International Bureau for processing in its capacity as a Receiving Office (PCT Rule 19.4).</P>
+            <P>(b) The international filing fee shall be as prescribed in PCT Rule 15.</P>
+          </SECTION>
+        </REGTEXT>
+        <REGTEXT PART="1" TITLE="37">
+          <AMDPAR>5. Section 1.482 is revised to read as follows:</AMDPAR>
+          <SECTION>
+            <SECTNO>§ 1.482 </SECTNO>
+            <SUBJECT>International preliminary examination fees.</SUBJECT>
+            <P>(a) The following fees and charges for international preliminary examination are established by the Director under the authority of 35 U.S.C. 376:</P>
+            <P>(1) The following preliminary examination fee is due on filing the Demand:</P>
+            <P>(i) If an international search fee as set forth in § 1.445(a)(2) has been paid on the international application to the United States Patent and Trademark Office as an International Searching Authority:</P>
+            <GPOTABLE CDEF="s50,10" COLS="2" OPTS="L0,tp0,p0,7/8,g1,t1,i1">
+              <TTITLE> </TTITLE>
+              <BOXHD>
+                <CHED H="1"> </CHED>
+                <CHED H="1"> </CHED>
+              </BOXHD>
+              <ROW>
+                <ENT I="22">(A) For an international preliminary examination fee paid on or after January 1, 2014:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$150.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a)) </ENT>
+                <ENT>$300.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$600.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(B) For an international preliminary examination fee paid before January 1, 2014</ENT>
+                <ENT>$600.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(ii) If the International Searching Authority for the international application was an authority other than the United States Patent and Trademark Office:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(A) For an international preliminary examination fee paid on or after January 1, 2014:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$190.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$380.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$760.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(B) For an international preliminary examination fee paid before January 1, 2014 $750.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(2) An additional preliminary examination fee when required, per additional invention:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="22">(i) If the international preliminary examination fee set forth in paragraph (a)(1) of this section was paid on or after January 1, 2014:</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a micro entity (§ 1.29)</ENT>
+                <ENT>$150.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By a small entity (§ 1.27(a))</ENT>
+                <ENT>$300.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="02">By other than a small or micro entity</ENT>
+                <ENT>$600.00</ENT>
+              </ROW>
+              <ROW>
+                <ENT I="01">(ii) If the international preliminary examination fee set forth in paragraph (a)(1) of this section was paid before January 1, 2014</ENT>
+                <ENT>$600.00</ENT>
+              </ROW>
+            </GPOTABLE>
+            <P>(b) The handling fee is due on filing the Demand and shall be prescribed in PCT Rule 57.</P>
+          </SECTION>
+        </REGTEXT>
+        <REGTEXT PART="41" TITLE="37">
+          <PART>
+            <HD SOURCE="HED">PART 41—PRACTICE BEFORE THE PATENT TRIAL AND APPEAL BOARD</HD>
+          </PART>
+          <AMDPAR>6. The authority citation for 37 CFR part 41 continues to read as follows:</AMDPAR>
+          <AUTH>
+            <HD SOURCE="HED">Authority:</HD>
+            <P> 35 U.S.C. 2(b)(2), 3(a)(2)(A), 21, 23, 32, 41, 134, 135, and Pub. L. 112-29.</P>
+          </AUTH>
+        </REGTEXT>
+        
+        <REGTEXT PART="41" TITLE="37">
+          <AMDPAR>7. Section 41.37 is amended by revising paragraphs (a) and (b) to read as follows:</AMDPAR>
+          <SECTION>
+            <SECTNO>§ 41.37 </SECTNO>
+            <SUBJECT>Appeal brief.</SUBJECT>
+            <P>(a) <E T="03">Timing.</E> Appellant must file a brief under this section within two months from the date of filing the notice of appeal under § 41.31. The appeal brief fee in an application or <E T="03">ex parte</E> reexamination proceeding is $0.00, but if the appeal results in an examiner's answer, the appeal forwarding fee set forth in § 41.20(b)(4) must be paid within the time period specified in § 41.45 to avoid dismissal of an appeal.</P>
+            <P>(b) <E T="03">Failure to file a brief.</E> On failure to file the brief within the period specified in paragraph (a) of this section, the appeal will stand dismissed.</P>
+            <STARS/>
+          </SECTION>
+        </REGTEXT>
+        <REGTEXT PART="41" TITLE="37">
+          <AMDPAR>8. Section 41.45 is revised to read as follows:</AMDPAR>
+          <SECTION>
+            <SECTNO>§ 41.45 </SECTNO>
+            <SUBJECT>Appeal forwarding fee.</SUBJECT>
+            <P>(a) <E T="03">Timing.</E> Appellant in an application or <E T="03">ex parte</E> reexamination proceeding must pay the fee set forth in § 41.20(b)(4) within the later of two months from the date of either the examiner's answer, or a decision refusing to grant a petition under § 1.181 of this chapter to designate a new ground of rejection in an examiner's answer.</P>
+            <P>(b) <E T="03">Failure to pay appeal forwarding fee.</E> On failure to pay the fee set forth in § 41.20(b)(4) within the period specified in paragraph (a) of this section, the appeal will stand dismissed.<PRTPAGE P="17108"/>
+            </P>
+            <P>(c) <E T="03">Extensions of time.</E> Extensions of time under § 1.136(a) of this title for patent applications are not applicable to the time period set forth in this section. <E T="03">See</E> § 1.136(b) of this title for extensions of time to reply for patent applications and § 1.550(c) of this title for extensions of time to reply for <E T="03">ex parte</E> reexamination proceedings.</P>
+          </SECTION>
+        </REGTEXT>
+        <SIG>
+          <DATED>Dated: March 14, 2013.</DATED>
+          <NAME>Teresa Stanek Rea,</NAME>
+          <TITLE>Acting Under Secretary of Commerce for Intellectual Property and Acting Director of the United States Patent and Trademark Office.</TITLE>
+        </SIG>
+      </SUPLINF>
+      <FRDOC>[FR Doc. 2013-06362 Filed 3-19-13; 8:45 am]</FRDOC>
+      <BILCOD>BILLING CODE 3510-16-P</BILCOD>
+    </RULE>


### PR DESCRIPTION
[FR 2013-06362](https://www.federalregister.gov/documents/2013/03/20/2013-06362/setting-and-adjusting-patent-fees-correction) modifies the `GPOTABLE` previously repaired as part of PR #7.  This notice is repaired in the same way by pushing the § 1.17 (j) marker into the adjoining `GPOTABLE` to place it at the same depth as its sibling markers.